### PR TITLE
Sudden find: fix within first "forget" example

### DIFF
--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -58,7 +58,7 @@ command and specify the snapshot ID on the command line:
 
     $ restic -r /srv/restic-repo forget bdbd3439
     enter password for repository:
-    removed snapshot d3f01f63
+    removed snapshot bdbd3439
 
 Afterwards this snapshot is removed:
 


### PR DESCRIPTION
I think this was a typo or copy/paste problem when created the doc.
Feel free to merge. Cheers


What does this PR change? What problem does it solve?
-----------------------------------------------------
Small fix of a typo (or a mislead) in documentation

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No - but it's simple, clear

Checklist
---------

- [ ] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
